### PR TITLE
Another small cleanup

### DIFF
--- a/gameduino2/convert.py
+++ b/gameduino2/convert.py
@@ -9,48 +9,46 @@ from gameduino2.imbytes import imbytes
 from gameduino2.registers import ARGB1555, ARGB2, ARGB4, L1, L2, L4, L8, PALETTED, RGB332, RGB565
 
 
-def convert(im, dither = False, fmt = ARGB1555):
+def convert(im, dither=False, fmt=ARGB1555):
     """ Convert PIL image to GD2 format, optionally dithering"""
-    im = im.convert({
-        ARGB1555 : "RGBA",
-        L1 : "L",
-        L2 : "L",
-        L4 : "L",
-        L8 : "L",
-        RGB332 : "RGB",
-        ARGB2 : "RGBA",
-        ARGB4 : "RGBA",
-        RGB565 : "RGB",
-        PALETTED : "RGB"}[fmt])
+    im = im.convert({ARGB1555: "RGBA",
+                     L1: "L",
+                     L2: "L",
+                     L4: "L",
+                     L8: "L",
+                     RGB332: "RGB",
+                     ARGB2: "RGBA",
+                     ARGB4: "RGBA",
+                     RGB565: "RGB",
+                     PALETTED: "RGB"}[fmt])
     imdata = []
-    colorfmts = {
-        ARGB1555 : (1, 5, 5, 5),
-        RGB332 :   (0, 3, 3, 2),
-        ARGB2 :    (2, 2, 2, 2),
-        ARGB4 :    (4, 4, 4, 4),
-        RGB565 :   (0, 5, 6, 5)}
+    colorfmts = {ARGB1555: (1, 5, 5, 5),
+                 RGB332: (0, 3, 3, 2),
+                 ARGB2: (2, 2, 2, 2),
+                 ARGB4: (4, 4, 4, 4),
+                 RGB565: (0, 5, 6, 5)}
     if dither:
         rnd = random.Random()
         rnd.seed(0)
     if fmt in colorfmts:
         im = im.convert("RGBA")
-        (asz,rsz,gsz,bsz) = colorfmts[fmt]
-        totalsz = sum((asz,rsz,gsz,bsz))
-        assert totalsz in (8,16)
+        (asz, rsz, gsz, bsz) = colorfmts[fmt]
+        totalsz = sum((asz, rsz, gsz, bsz))
+        assert totalsz in (8, 16)
         for y in range(im.size[1]):
             for x in range(im.size[0]):
-                (r,g,b,a) = im.getpixel((x,y))
+                (r, g, b, a) = im.getpixel((x, y))
                 if dither:
-                    a = min(255, a + rnd.randrange(256>>asz))
-                    r = min(255, r + rnd.randrange(256>>rsz))
-                    g = min(255, g + rnd.randrange(256>>gsz))
-                    b = min(255, b + rnd.randrange(256>>bsz))
-                binary = ((a >> (8-asz)) << (bsz+gsz+rsz)) | ((r >> (8-rsz)) << (gsz+bsz)) | ((g >> (8-gsz)) << (bsz)) | (b >> (8-bsz))
+                    a = min(255, a + rnd.randrange(256 >> asz))
+                    r = min(255, r + rnd.randrange(256 >> rsz))
+                    g = min(255, g + rnd.randrange(256 >> gsz))
+                    b = min(255, b + rnd.randrange(256 >> bsz))
+                binary = ((a >> (8 - asz)) << (bsz + gsz + rsz)) | ((r >> (8 - rsz)) << (gsz + bsz)) | ((g >> (8 - gsz)) << (bsz)) | (b >> (8 - bsz))
                 imdata.append(binary)
-        fmtchr = {8:'B',16:'H'}[totalsz]
+        fmtchr = {8: 'B', 16: 'H'}[totalsz]
         data = array.array('B', array.array(fmtchr, imdata).tostring())
     elif fmt == PALETTED:
-        im = im.convert("P", palette = Image.ADAPTIVE)
+        im = im.convert("P", palette=Image.ADAPTIVE)
         lut = im.resize((256, 1))
         lut.putdata(range(256))
         palstr = lut.convert("RGBA").tobytes()
@@ -61,6 +59,7 @@ def convert(im, dither = False, fmt = ARGB1555):
     elif fmt == L4:
         b0 = imbytes(im)[::2]
         b1 = imbytes(im)[1::2]
+
         def to15(c):
             if dither:
                 dc = min(255, c + rnd.randrange(16))
@@ -68,12 +67,13 @@ def convert(im, dither = False, fmt = ARGB1555):
                 dc = c
             return int((15 * dc / 255))
 
-        data = array.array('B', [(16 * to15(l) + to15(r)) for (l,r) in zip(b0, b1)])
+        data = array.array('B', [(16 * to15(l) + to15(r)) for (l, r) in zip(b0, b1)])
     elif fmt == L2:
         b0 = imbytes(im)[::4]
         b1 = imbytes(im)[1::4]
         b2 = imbytes(im)[2::4]
         b3 = imbytes(im)[3::4]
+
         def to3(c):
             if dither:
                 dc = min(255, c + rnd.randrange(64))
@@ -81,7 +81,7 @@ def convert(im, dither = False, fmt = ARGB1555):
                 dc = c
             return int((3 * dc / 255))
 
-        data = array.array('B', [(64 * to3(a) + 16 * to3(b) + 4 * to3(c) + to3(d)) for (a,b,c,d) in zip(b0, b1, b2, b3)])
+        data = array.array('B', [(64 * to3(a) + 16 * to3(b) + 4 * to3(c) + to3(d)) for (a, b, c, d) in zip(b0, b1, b2, b3)])
     elif fmt == L1:
         if dither:
             im = im.convert("1", dither=Image.FLOYDSTEINBERG)

--- a/gameduino2/convert.py
+++ b/gameduino2/convert.py
@@ -89,5 +89,5 @@ def convert(im, dither=False, fmt=ARGB1555):
             im = im.convert("1", dither=Image.NONE)
         data = imbytes(im)
     else:
-        assert 0, "Bad format %r" % fmt
+        assert 0, "Bad format {!r}".format(fmt)
     return (im.size, data)

--- a/gameduino2/convert.py
+++ b/gameduino2/convert.py
@@ -3,8 +3,9 @@ import random
 
 from PIL import Image
 
-from gameduino2.registers import *
 from gameduino2.imbytes import imbytes
+from gameduino2.registers import ARGB1555, ARGB2, ARGB4, L1, L2, L4, L8, PALETTED, RGB332, RGB565
+
 
 def convert(im, dither = False, fmt = ARGB1555):
     """ Convert PIL image to GD2 format, optionally dithering"""
@@ -64,7 +65,7 @@ def convert(im, dither = False, fmt = ARGB1555):
             else:
                 dc = c
             return int((15. * dc / 255))
-                
+
         data = array.array('B', [(16 * to15(l) + to15(r)) for (l,r) in zip(b0, b1)])
     elif fmt == L2:
         b0 = imbytes(im)[::4]
@@ -77,7 +78,7 @@ def convert(im, dither = False, fmt = ARGB1555):
             else:
                 dc = c
             return int((3. * dc / 255))
-                
+
         data = array.array('B', [(64 * to3(a) + 16 * to3(b) + 4 * to3(c) + to3(d)) for (a,b,c,d) in zip(b0, b1, b2, b3)])
     elif fmt == L1:
         if dither:

--- a/gameduino2/convert.py
+++ b/gameduino2/convert.py
@@ -43,7 +43,7 @@ def convert(im, dither=False, fmt=ARGB1555):
                     r = min(255, r + rnd.randrange(256 >> rsz))
                     g = min(255, g + rnd.randrange(256 >> gsz))
                     b = min(255, b + rnd.randrange(256 >> bsz))
-                binary = ((a >> (8 - asz)) << (bsz + gsz + rsz)) | ((r >> (8 - rsz)) << (gsz + bsz)) | ((g >> (8 - gsz)) << (bsz)) | (b >> (8 - bsz))
+                binary = ((a >> (8 - asz)) << (bsz + gsz + rsz)) | ((r >> (8 - rsz)) << (gsz + bsz)) | ((g >> (8 - gsz)) << bsz) | (b >> (8 - bsz))
                 imdata.append(binary)
         fmtchr = {8: 'B', 16: 'H'}[totalsz]
         data = array.array('B', array.array(fmtchr, imdata).tostring())
@@ -90,4 +90,4 @@ def convert(im, dither=False, fmt=ARGB1555):
         data = imbytes(im)
     else:
         assert 0, "Bad format {!r}".format(fmt)
-    return (im.size, data)
+    return im.size, data

--- a/gameduino2/convert.py
+++ b/gameduino2/convert.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import array
 import random
 
@@ -64,7 +66,7 @@ def convert(im, dither = False, fmt = ARGB1555):
                 dc = min(255, c + rnd.randrange(16))
             else:
                 dc = c
-            return int((15. * dc / 255))
+            return int((15 * dc / 255))
 
         data = array.array('B', [(16 * to15(l) + to15(r)) for (l,r) in zip(b0, b1)])
     elif fmt == L2:
@@ -77,7 +79,7 @@ def convert(im, dither = False, fmt = ARGB1555):
                 dc = min(255, c + rnd.randrange(64))
             else:
                 dc = c
-            return int((3. * dc / 255))
+            return int((3 * dc / 255))
 
         data = array.array('B', [(64 * to3(a) + 16 * to3(b) + 4 * to3(c) + to3(d)) for (a,b,c,d) in zip(b0, b1, b2, b3)])
     elif fmt == L1:

--- a/gameduino2/imbytes.py
+++ b/gameduino2/imbytes.py
@@ -1,9 +1,9 @@
 import array
 
+
 def imbytes(im):
     try:
         bb = im.tobytes()
     except AttributeError:
         bb = im.tostring()
     return array.array('B', bb)
-

--- a/gameduino2/registers.py
+++ b/gameduino2/registers.py
@@ -1,10 +1,5 @@
+from __future__ import division
 
-def RGB(r, g, b):
-    return (r << 16) | (g << 8) | b
-
-def DEGREES(n):
-    # Convert degrees to Furmans
-    return 65536 * n / 360
 
 NEVER                = 0
 LESS                 = 1
@@ -194,10 +189,20 @@ REG_VSIZE            = 1057860
 REG_VSYNC0           = 1057864
 REG_VSYNC1           = 1057868
 
-def VERTEX2II(x, y, handle, cell):
-    return ((2 << 30) | ((x & 511) << 21) | ((y & 511) << 12) | ((handle & 31) << 7) | ((cell & 127) << 0))
-
 RED                  = 2
 GREEN                = 3
 BLUE                 = 4
 ALPHA                = 5
+
+
+def VERTEX2II(x, y, handle, cell):
+    return (2 << 30) | ((x & 511) << 21) | ((y & 511) << 12) | ((handle & 31) << 7) | ((cell & 127) << 0)
+
+
+def RGB(r, g, b):
+    return (r << 16) | (g << 8) | b
+
+
+def DEGREES(n):
+    # Convert degrees to Furmans
+    return 65536 * n // 360

--- a/gameduino2/remote.py
+++ b/gameduino2/remote.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import struct
 import zlib
 
@@ -13,13 +15,16 @@ try:
 except ImportError:
     from io import StringIO  # Python 3
 
+
 def pad4(s):
     while len(s) % 4:
         s += chr(0)
     return s
 
+
 class GD2Exception(Exception):
     pass
+
 
 class GD2(gameduino2.base.GD2):
 
@@ -49,7 +54,7 @@ class GD2(gameduino2.base.GD2):
         self.wr32(reg.REG_PCLK_POL, 1)
 
         self.cmd_dlstart()
-        self.Clear(1,1,1)
+        self.Clear(1, 1, 1)
         self.Display()
         self.cmd_swap()
         self.cmd_regwrite(reg.REG_PCLK, 5)
@@ -113,27 +118,27 @@ class GD2(gameduino2.base.GD2):
         c = self.cc.getvalue()
         self.cc = StringIO()
         for i in range(0, len(c), 4096):
-            res = self.command(c[i:i+4096])
+            res = self.command(c[i:i + 4096])
         # self.v.waitidle()
 
     def c(self, cmdstr):
         self.cc.write(pad4(cmdstr))
 
-    def load_image(self, im, dither = False, fmt = reg.ARGB1555, sampling = reg.NEAREST, zoom = 1):
+    def load_image(self, im, dither=False, fmt=reg.ARGB1555, sampling=reg.NEAREST, zoom=1):
         strides = {
-            reg.L1 :       lambda w: w / 8,
-            reg.L4 :       lambda w: w / 2,
-            reg.L8 :       lambda w: w,
-            reg.RGB332 :   lambda w: w,
-            reg.ARGB2 :    lambda w: w,
-            reg.PALETTED : lambda w: w,
+            reg.L1: lambda w: w // 8,
+            reg.L4: lambda w: w // 2,
+            reg.L8: lambda w: w,
+            reg.RGB332: lambda w: w,
+            reg.ARGB2: lambda w: w,
+            reg.PALETTED: lambda w: w,
         }
         if fmt == reg.L1:
             i = Image.new(im.mode, ((im.size[0] + 7) & ~7, im.size[1]))
-            i.paste(im, (0,0))
+            i.paste(im, (0, 0))
             im = i
         stride = strides.get(fmt, lambda w: 2 * w)(im.size[0])
-        (_,da) = convert.convert(im, dither = dither, fmt = fmt)
+        (_, da) = convert.convert(im, dither=dither, fmt=fmt)
         self.ramptr = (self.ramptr + 1) & ~1
         self.zload(self.ramptr, da.tostring())
         self.BitmapSize(sampling, reg.BORDER, reg.BORDER, min(511, zoom * im.size[0]), min(511, zoom * im.size[1]))

--- a/gameduino2/remote.py
+++ b/gameduino2/remote.py
@@ -1,22 +1,22 @@
-import sys
-import array
-import StringIO
-import zlib
 import struct
-import time
+import zlib
 
-PYTHON2 = (sys.version_info < (3, 0))
+from PIL import Image
 
-import Image
-import convert
+import gameduino2.base
+import gameduino2.registers as reg
+from gameduino2 import convert
+
+try:
+    # noinspection PyUnresolvedReferences,PyCompatibility
+    from StringIO import StringIO  # Python 2
+except ImportError:
+    from io import StringIO  # Python 3
 
 def pad4(s):
     while len(s) % 4:
         s += chr(0)
     return s
-
-import gameduino2.registers as reg
-import gameduino2.base
 
 class GD2Exception(Exception):
     pass
@@ -27,7 +27,7 @@ class GD2(gameduino2.base.GD2):
         self.ramptr = 0
         self.wp = 0
 
-        self.cc = StringIO.StringIO()
+        self.cc = StringIO()
         self.transport = transport
 
         self.transport.reset()
@@ -111,7 +111,7 @@ class GD2(gameduino2.base.GD2):
 
     def finish(self):
         c = self.cc.getvalue()
-        self.cc = StringIO.StringIO()
+        self.cc = StringIO()
         for i in range(0, len(c), 4096):
             res = self.command(c[i:i+4096])
         # self.v.waitidle()


### PR DESCRIPTION
Same as before.   

I'm a little nervous about this original code:
`int((15. * dc / 255))`

new code: 

```python
from __future__ import division
int((15 * dc / 255))
```

There are a number of ways that this number could come out.  By moving over to the Python3 style division it should always be the same type inside the `int()`  i.e.` Int * Float` instead of `Float * Int|Float`  

`int()` is effectively flooring the float by truncating floatiness .   Is that desired? 